### PR TITLE
Using Longitude and Latitude in mockup Charger API

### DIFF
--- a/app/src/main/java/com/flexicharge/bolt/FakeJsonResponse.kt
+++ b/app/src/main/java/com/flexicharge/bolt/FakeJsonResponse.kt
@@ -2,7 +2,12 @@ package com.flexicharge.bolt
 
 data class FakeJsonResponse(
     val id: Int,
-    val location: String,
+    val location: Location,
     val chargePointId: Int,
     val status: Int
+)
+
+data class Location(
+    val latitude: Double,
+    val longitude: Double
 )

--- a/app/src/main/java/com/flexicharge/bolt/MainActivity.kt
+++ b/app/src/main/java/com/flexicharge/bolt/MainActivity.kt
@@ -111,15 +111,15 @@ class MainActivity : AppCompatActivity() {
             try {
                 val response = RetrofitInstance.api.getMockApiData(chargerId)
                 if (response.isSuccessful) {
-                    val chargerId = response.body() as FakeJsonResponse
-                    Log.d("validateConnection", "Connected to charger " + chargerId.id)
+                    val charger = response.body() as FakeJsonResponse
+                    Log.d("validateConnection", "Connected to charger " + charger.id)
                     lifecycleScope.launch(Dispatchers.Main) {
-                        if (chargerId.status == 1) {
-                            chargerInputStatus.text = "Connected to charger " + chargerId.id
+                        if (charger.status == 1) {
+                            chargerInputStatus.text = "Connected to charger " + charger.id + "\n located at Long:" + charger.location.longitude + " Lat:" + charger.location.latitude
                             chargerInputStatus.setBackgroundResource(R.color.green)
                         }
                         else {
-                            chargerInputStatus.text = "Charger " + chargerId.id + " is busy"
+                            chargerInputStatus.text = "Charger " + charger.id + " is busy"
                             chargerInputStatus.setBackgroundResource(R.color.red)
                         }
                     }


### PR DESCRIPTION
This will allow us to use the exact location of chargers.
See function `fun validateConnectionToMockDataApi` inside MainActivity for an example of how to access Longitude and Latitude.