### PR TITLE
Refactor/remote objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,27 @@
 # Documentation for FlexiCharge Native Android Application
 
 ## Project Architecture
-
-* ### This branch (main)
+* ### RemoteObject
+    #### What are "RemoteObjects"?
+    * All endpoints on the backend that is of importance to the application should have a corresponding class inheriting from ```RemoteObject```.
+    * For example, for the endpoint "/transactions" there is a class ```RemoteTransaction``` which inherits from ```RemoteObject<Transaction>```
+    * All functionality of the endpoint should be contained within its ```RemoteObject``` class.
+    #### How do you implement a RemoteObject?
+    * Define a ```data class``` summarizing the information to be contained within the remote object.
+    * Make sure that the layout and the names of the fields in the ```data class``` matches its corresponding JSON object, provided by the backend team.
+    * The ```data class``` ```Chargers``` for example contains the information returned by the API-call ```GET /chargers```.
+    * Create a class inheriting from ```RemoteObject<T>```.
+    * For example, the class ```RemoteChargers``` inherits from ```RemoteObject<Chargers>```.
+    * Implement its abstract methods and properties (android studio can help you in doing this, just hover over what's red and perform the recommended action.)
+    * Check the existing Remote____ classes for reference on how to implement API-calls.
+    * Don't forget to use ```withTimeout()``` when making API calls!
+    #### How do you use a RemoteObject?
+    * All RemoteObjects implement the method ```refresh()``` which utilizes the abstract method ```retrieve()```.
+    * ```retrieve()``` should implement the most basic /GET request you can make to the end-point.
+    * ```refresh()``` in turn calls the onRefreshed callback which can be defined with the method ```setOnRefreshedCallback()```.
+    * All operations performed by a remote object should return a ```Job```instance, which you can store in a variable.
+    * To perform an action after the API-call has been succesfully made, use the method ```Job.invokeOnCompletion()```.
+    * To check whether the API-call succeeded you can consult the property ```Job.isCancelled``` to ```return@invokeOnCompletion``` if it failed.
 
   This branch works with Android Studio 2020.3.1, uses Android SDK 30 and supports Android 10 and above.
 
@@ -27,6 +46,7 @@
 1. Open project in Android Studio
 2. Let gradle download all required modules
 3. Compile and run application by clicking "Run"
+
 
 ### Using the app
 

--- a/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteChargePoints.kt
+++ b/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteChargePoints.kt
@@ -5,10 +5,7 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.lifecycleScope
 import com.flexicharge.bolt.api.flexicharge.ChargePoints
 import com.flexicharge.bolt.api.flexicharge.RetrofitInstance
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import retrofit2.HttpException
 import java.io.IOException
 
@@ -17,16 +14,18 @@ class RemoteChargePoints() : RemoteObject<ChargePoints>() {
 
     override fun retrieve(lifecycleScope: LifecycleCoroutineScope): Job {
         return lifecycleScope.launch(Dispatchers.IO) {
-            try {
-                val response = RetrofitInstance.flexiChargeApi.getChargePointList()
-                value = response.body() as ChargePoints
+            withTimeout(REMOTE_OBJECT_TIMEOUT_MILLISECONDS) {
+                try {
+                    val response = RetrofitInstance.flexiChargeApi.getChargePointList()
+                    value = response.body() as ChargePoints
 
-            } catch (e: HttpException) {
-                Log.d("validateConnection", "Http Error")
-                cancel(e.message())
-            } catch (e: IOException) {
-                Log.d("validateConnection", "No Internet Error - ChargePointList will not be initialized")
-                cancel(e.toString())
+                } catch (e: HttpException) {
+                    Log.d("validateConnection", "Http Error")
+                    cancel(e.message())
+                } catch (e: IOException) {
+                    Log.d("validateConnection", "No Internet Error - ChargePointList will not be initialized")
+                    cancel(e.toString())
+                }
             }
         }
     }

--- a/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteCharger.kt
+++ b/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteCharger.kt
@@ -4,34 +4,60 @@ import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.lifecycleScope
 import com.flexicharge.bolt.api.flexicharge.Charger
 import com.flexicharge.bolt.api.flexicharge.RetrofitInstance
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import retrofit2.HttpException
 import java.io.IOException
 
 class RemoteCharger(private var id: Int = -1) : RemoteObject<Charger>() {
 
     override var value: Charger =
-        Charger(id, -1, listOf(0.0, 0.0), "", "")
+        Charger(0, id, listOf(0.0, 0.0), "", "")
+
+    var status: String = ""
+        private set
 
     override fun retrieve(lifecycleScope: LifecycleCoroutineScope): Job {
         return lifecycleScope.launch(Dispatchers.IO) {
-            val cancelMessage = "Could not retrieve all data properly"
-            try {
-                val response = RetrofitInstance.flexiChargeApi.getCharger(id)
-                if(response.isSuccessful) {
-                    value = response.body() as Charger
-                }
-                else {
-                    cancel(response.message())
-                }
+            withTimeout(REMOTE_OBJECT_TIMEOUT_MILLISECONDS) {
+                val cancelMessage = "Could not retrieve all data properly"
+                try {
+                    val response = RetrofitInstance.flexiChargeApi.getCharger(id)
+                    if(response.isSuccessful) {
+                        value = response.body() as Charger
+                    }
+                    else {
+                        cancel(response.message())
+                    }
 
-            } catch (e: HttpException) {
-                cancel(cancelMessage)
-            } catch (e: IOException) {
-                cancel(cancelMessage)
+                } catch (e: HttpException) {
+                    cancel(cancelMessage)
+                } catch (e: IOException) {
+                    cancel(cancelMessage)
+                }
+            }
+        }
+    }
+
+    fun reserve(lifecycleScope: LifecycleCoroutineScope): Job {
+        return lifecycleScope.launch (Dispatchers.IO){
+            withTimeout(REMOTE_OBJECT_TIMEOUT_MILLISECONDS) {
+                try {
+                    val requestParams: MutableMap<String, String> = HashMap()
+                    requestParams["chargerId"] = value.chargerID.toString()
+                    requestParams["connectorId"] = "1"
+                    requestParams["idTag"] = "1"
+                    requestParams["reservationId"] = "1"
+                    requestParams["parentIdTag"] = "1"
+                    val response = RetrofitInstance.flexiChargeApi.reserveCharger(value.chargerID, requestParams)
+                    if(!response.isSuccessful) {
+                        cancel(response.message())
+                    }
+
+                    status = response.body() as String
+                }
+                catch (e: Exception) {
+                    cancel(CancellationException(e.message))
+                }
             }
         }
     }

--- a/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteChargers.kt
+++ b/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteChargers.kt
@@ -19,21 +19,24 @@ class RemoteChargers() : RemoteObject<Chargers>() {
     override fun retrieve(lifecycleScope: LifecycleCoroutineScope) : Job {
 
         val refreshJob = lifecycleScope.launch(Dispatchers.IO) {
-            try {
-                val response = RetrofitInstance.flexiChargeApi.getChargerList() // Retrofit is a REST Client, Retrieve and upoad JSON
-                if (!response.isSuccessful) {
-                    cancel("Failed retrieving chargers")
+            withTimeout(REMOTE_OBJECT_TIMEOUT_MILLISECONDS) {
+                try {
+                    val response = RetrofitInstance.flexiChargeApi.getChargerList() // Retrofit is a REST Client, Retrieve and upoad JSON
+                    if (!response.isSuccessful) {
+                        cancel("Failed retrieving chargers")
+                    }
+
+                    value = response.body() as Chargers
+
+
+                } catch (e: HttpException) {
+                    Log.d("validateConnection", "Http Error")
+                    cancel(e.message())
+                } catch (e: IOException) {
+                    Log.d("validateConnection", "No Internet Error - ChargerList will not be initialized")
+                    cancel(e.toString())
                 }
 
-                value = response.body() as Chargers
-
-
-            } catch (e: HttpException) {
-                Log.d("validateConnection", "Http Error")
-                cancel(e.message())
-            } catch (e: IOException) {
-                Log.d("validateConnection", "No Internet Error - ChargerList will not be initialized")
-                cancel(e.toString())
             }
         }
 

--- a/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteObject.kt
+++ b/app/src/main/java/com/flexicharge/bolt/activities/businessLogic/RemoteObject.kt
@@ -1,11 +1,14 @@
 package com.flexicharge.bolt.activities.businessLogic
 
 import androidx.lifecycle.LifecycleCoroutineScope
-import com.flexicharge.bolt.api.flexicharge.Chargers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.withTimeout
 
 abstract class RemoteObject<T> {
-    data class RemoteObjectJob<T>(val job: Job, val value: T)
+
+    companion object {
+        const val REMOTE_OBJECT_TIMEOUT_MILLISECONDS = 1300L
+    }
 
     abstract var value: T
         protected set
@@ -21,6 +24,7 @@ abstract class RemoteObject<T> {
     fun refresh(lifecycleScope: LifecycleCoroutineScope) : Job {
 
         val remoteObjectJob = retrieve(lifecycleScope)
+
         remoteObjectJob.invokeOnCompletion {
             if(remoteObjectJob.isCancelled) {
                 return@invokeOnCompletion


### PR DESCRIPTION
### Refactors MainActivity.kt so that no API-calls are made directly in its presentation layer
#### This is done through a new class **RemoteObject**:
> - RemoteObjects help maintain synchronization with the backend.
> - RemoteObjects also bring a sense of cohesiveness within the codebase.
> - A certain operation utilizing the backend is now only written in one place, so that if it needs to be changed, it only needs to be changed in one place.
> - RemoteObjects also help standardize the process of handling failed API-calls.
